### PR TITLE
Promised BNF Grammar `import`/`imports` Statement Fixes

### DIFF
--- a/partial-language-definition-in-BNF.md
+++ b/partial-language-definition-in-BNF.md
@@ -16,10 +16,10 @@ members: member | members ;
 visibility: <currently undefined> ;
 storage-spec: <currently undefined> ;
 parameter-list: '('[any whitespace]')' |
-  '(' plist ')' ;
-plist: plist-item |
-  plist-item ',' plist ;
-plist-item: typespec identifier |
+  '(' param-list ')' ;
+param-list: param-list-item |
+  param-list-item ',' param-list ;
+param-list-item: typespec identifier |
   typespec identifer ASSIGN constant ;
 return-spec: typespec ;
 expressions: all-expr |

--- a/partial-language-definition-in-BNF.md
+++ b/partial-language-definition-in-BNF.md
@@ -1,8 +1,8 @@
 ###Syntax Description
 ```
 compilation-unit: prologue object | object ;
-prologue: import | imports ;
-imports: import imports ;
+prologue: imports ;
+imports: import | import ',' imports ;
 import: IMPORT identifier FROM identifier AS identifier EOL ;
 object: object-header { object-body } ;
 object-header: OBJECT identifier | OBJECT identifier inheritance ;


### PR DESCRIPTION
Here are the fixes I proposed in [this comment](https://github.com/dshadowwolf/ideas-for-a-new-language/commit/abc693331f5a427ca5099df231987fcaed643234#commitcomment-19762059) on [commit `abc6933`](https://github.com/dshadowwolf/ideas-for-a-new-language/commit/abc693331f5a427ca5099df231987fcaed643234) a while back.  Note, however, that they are slightly different from what I originally suggested since I noticed a problem with respect to recursively in my initial attempt.  